### PR TITLE
Fix sequoias

### DIFF
--- a/TFC_Shared/src/TFC/Blocks/BlockLogNatural.java
+++ b/TFC_Shared/src/TFC/Blocks/BlockLogNatural.java
@@ -21,7 +21,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 public class BlockLogNatural extends BlockTerra
-{	
+{
 	public BlockLogNatural(int i) 
 	{
 		super(i, Material.wood);
@@ -31,19 +31,21 @@ public class BlockLogNatural extends BlockTerra
 	@Override
     public void updateTick(World world, int i, int j, int k, Random rand)
     {
-		if(!world.isRemote)
-		{
-			if(!world.isBlockOpaqueCube(i, j-1, k))
-			{
-				if(world.getBlockId(i+1, j, k) != blockID && world.getBlockId(i-1, j, k) != blockID && 
-						world.getBlockId(i, j, k+1) != blockID && world.getBlockId(i, j, k-1) != blockID && 
-						world.getBlockId(i+1, j, k+1) != blockID && world.getBlockId(i+1, j, k-1) != blockID && 
-						world.getBlockId(i-1, j, k+1) != blockID && world.getBlockId(i-1, j, k-1) != blockID)
-				{
-					world.setBlock(i, j, k, 0);
-				}
-			}
-		}
+		if (world.isRemote) return;
+		
+		if (world.isBlockOpaqueCube(i, j-1, k)) return;
+		
+		if (world.getBlockId(i+1, j, k  ) == blockID || 
+		    world.getBlockId(i-1, j, k  ) == blockID || 
+		    world.getBlockId(i  , j, k+1) == blockID || 
+		    world.getBlockId(i  , j, k-1) == blockID || 
+		    world.getBlockId(i+1, j, k+1) == blockID || 
+		    world.getBlockId(i+1, j, k-1) == blockID || 
+		    world.getBlockId(i-1, j, k+1) == blockID || 
+		    world.getBlockId(i-1, j, k-1) == blockID) 
+			return;
+		
+		world.setBlock(i, j, k, 0);
     }
 
 	@SideOnly(Side.CLIENT)
@@ -53,7 +55,8 @@ public class BlockLogNatural extends BlockTerra
 	 */
 	public void getSubBlocks(int par1, CreativeTabs par2CreativeTabs, List list)
 	{
-		for(int i = 0; i < Global.WOOD_ALL.length; i++) {
+		for (int i = 0; i < Global.WOOD_ALL.length; i++) 
+		{
 			list.add(new ItemStack(this,1,i));
 		}
 	}
@@ -66,10 +69,8 @@ public class BlockLogNatural extends BlockTerra
 
 	private boolean checkOut(World world, int i, int j, int k, int l)
 	{
-		if(world.getBlockId(i, j, k) == blockID && world.getBlockMetadata(i, j, k) == l)
-		{
+		if (world.getBlockId(i, j, k) == blockID && world.getBlockMetadata(i, j, k) == l) 
 			return true;
-		}
 		return false;
 	}
 
@@ -81,14 +82,8 @@ public class BlockLogNatural extends BlockTerra
 	@Override
 	public Icon getIcon(int i, int j) 
 	{
-		if (i == 1)
-		{
+		if (i == 0 || i == 1)
 			return innerIcons[j];
-		}
-		if (i == 0)
-		{
-			return innerIcons[j];
-		}
 		return sideIcons[j];
 	}
 	
@@ -99,7 +94,7 @@ public class BlockLogNatural extends BlockTerra
 	@Override
     public void registerIcons(IconRegister registerer)
     {
-		for(int i = 0; i < Global.WOOD_ALL.length; i++)
+		for (int i = 0; i < Global.WOOD_ALL.length; i++)
 		{
 			sideIcons[i] = registerer.registerIcon(Reference.ModID + ":" + "wood/trees/" + Global.WOOD_ALL[i] + " Log");
 			innerIcons[i] = registerer.registerIcon(Reference.ModID + ":" + "wood/trees/" + Global.WOOD_ALL[i] + " Log Top");
@@ -113,64 +108,67 @@ public class BlockLogNatural extends BlockTerra
 	@Override
 	public void harvestBlock(World world, EntityPlayer entityplayer, int i, int j, int k, int l)
 	{		
+		if (world.isRemote) return;
+
 		//we need to make sure the player has the correct tool out
 		boolean isAxeorSaw = false;
 		boolean isHammer = false;
 		ItemStack equip = entityplayer.getCurrentEquippedItem();
-		if(!world.isRemote)
+		
+		if (equip==null)
 		{
-			if(equip!=null)
+			world.setBlock(i, j, k, blockID, l, 0x2);
+			return;
+		}
+		
+		for (int cnt = 0; cnt < Recipes.Axes.length; cnt++)
+		{
+			if (equip.getItem() == Recipes.Axes[cnt])
 			{
-				for(int cnt = 0; cnt < Recipes.Axes.length && !isAxeorSaw; cnt++)
-				{
-					if(equip.getItem() == Recipes.Axes[cnt])
-					{
-						isAxeorSaw = true;
-						if(cnt < 4)
-							isStone = true;
-					}
-				}
-//				for(int cnt = 0; cnt < Recipes.Saws.length && !isAxeorSaw; cnt++)
-//				{
-//					if(equip.getItem() == Recipes.Saws[cnt])
-//					{
-//						isAxeorSaw = true;
-//					}
-//				}
-				for(int cnt = 0; cnt < Recipes.Hammers.length && !isAxeorSaw; cnt++)
-				{
-					if(equip.getItem() == Recipes.Hammers[cnt])
-					{
-						isHammer = true;
-					}
-				}
-			}
-			if(isAxeorSaw)
-			{
-				damage = -1;
-				ProcessTree(world, i, j, k, l, equip);	
-				
-				if(damage + equip.getItemDamage() > equip.getMaxDamage())
-				{
-					int ind = entityplayer.inventory.currentItem;
-					entityplayer.inventory.setInventorySlotContents(ind, null);
-					world.setBlock(i, j, k, blockID, l, 0x2);
-				}
-				else
-				{
-					equip.damageItem(damage, entityplayer);
-				}
-			}
-			else if(isHammer)
-			{
-				EntityItem item = new EntityItem(world, i+0.5, j+0.5, k+0.5, new ItemStack(Item.stick, 1+world.rand.nextInt(3)));
-				world.spawnEntityInWorld(item);
-			}
-			else
-			{
-				world.setBlock(i, j, k, blockID, l, 0x2);
+				isAxeorSaw = true;
+				if (cnt < 4)
+					isStone = true;
+				break;
 			}
 		}
+//		if (!isAxeorSaw) 
+//		{
+//			for(int cnt = 0; cnt < Recipes.Saws.length; cnt++)
+//			{
+//				if(equip.getItem() == Recipes.Saws[cnt])
+//					isAxeorSaw = true;
+//			}
+//		}
+		if (!isAxeorSaw) {
+			for (int cnt = 0; cnt < Recipes.Hammers.length; cnt++)
+			{
+				if (equip.getItem() == Recipes.Hammers[cnt])
+					isHammer = true;
+					break;
+			}
+		}
+
+		if (!isAxeorSaw && !isHammer) return;
+
+		if (isHammer)
+		{
+			EntityItem item = new EntityItem(world, i+0.5, j+0.5, k+0.5, new ItemStack(Item.stick, 1+world.rand.nextInt(3)));
+			world.spawnEntityInWorld(item);
+			return;
+		}
+		
+		damage = -1;
+		ProcessTree(world, i, j, k, l, equip);	
+		
+		if(damage + equip.getItemDamage() <= equip.getMaxDamage())
+		{
+			equip.damageItem(damage, entityplayer);
+			return;
+		}
+		
+		int ind = entityplayer.inventory.currentItem;
+		entityplayer.inventory.setInventorySlotContents(ind, null);
+		world.setBlock(i, j, k, blockID, l, 0x2);
 	}
 	
 	@Override
@@ -185,35 +183,113 @@ public class BlockLogNatural extends BlockTerra
 		ProcessTree(world, i, j, k, world.getBlockMetadata(i, j, k), null);
 	}
 
-	private void ProcessTree(World world, int i, int j, int k, int l, ItemStack stack)
-	{
-		int x = i;
-		int y = 0;
-		int z = k;
-		boolean checkArray[][][] = new boolean[11][50][11];
+    class TreeScan {
+    	public World world;
+        public int i;
+        public int j;
+        public int k;
+        public int l;
+        public boolean checkArray[][][];
+        public int x;
+        public int y;
+        public int z;
+        public ItemStack stack;
+        public int xLength;
+        public int zLength;
+        public TreeScan(World world, int i, int j, int k, int l, boolean[][][] checkArray,int x, int y, int z, ItemStack stack) {
+        	this.world = world;
+            this.i = i;
+            this.j = j;
+            this.k = k;
+            this.l = l;
+            this.checkArray = checkArray;
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.stack = stack;
+            this.xLength = checkArray.length;
+            this.zLength = checkArray[0][0].length;
+        }
+        /**
+         * Recursion helper that creates a new instance with updated coordinates
+         * @return Returns a new scanner with the provided coordinates to help recursion
+         */
+        public TreeScan updateCoords(int i, int j, int k, int x, int y, int z) {
+        	return new TreeScan(this.world, i, j, k, this.l, this.checkArray, x, y, z, this.stack);
+        }
+    }
+    
+    private void ProcessTree(World world, int i, int j, int k, int l, ItemStack stack)
+    {
+    	TreeScan ts = new TreeScan(world, i, j, k, l, new boolean[11][50][11], 6, 0, 6, stack);
+        int x = i;
+        int y = 0;
+        int z = k;
 
-		boolean reachedTop = false;
-		while(!reachedTop)
-		{
-			if(l != 9 && l != 15 && world.getBlockId(x, j+y+1, z) == 0)
-			{
-				reachedTop = true;
-			}
-			else if((l == 9 || l == 15) && world.getBlockId(x, j+y+1, z) == 0
-					&& world.getBlockId(x+1, j+y+1, z) != blockID && world.getBlockId(x-1, j+y+1, z) != blockID && world.getBlockId(x, j+y+1, z+1) != blockID &&
-					world.getBlockId(x, j+y+1, z-1) != blockID && world.getBlockId(x-1, j+y+1, z-1) != blockID && world.getBlockId(x-1, j+y+1, z+1) != blockID && 
-					world.getBlockId(x+1, j+y+1, z+1) != blockID && world.getBlockId(x+1, j+y+1, z-1) != blockID)
-			{
-				reachedTop = true;
-			}
+        boolean reachedTop = false;
+       	while (!reachedTop) {
+       		if (world.getBlockId(x, j+y+1, z) == 0) {
+       			if (l != 9 && l != 15) {
+                    reachedTop = true;
+       			} else {
+					if (world.getBlockId(x+1, j+y+1, z  ) != blockID && 
+						world.getBlockId(x-1, j+y+1, z  ) != blockID && 
+					    world.getBlockId(x  , j+y+1, z+1) != blockID && 
+					    world.getBlockId(x  , j+y+1, z-1) != blockID && 
+					    world.getBlockId(x-1, j+y+1, z-1) != blockID && 
+					    world.getBlockId(x-1, j+y+1, z+1) != blockID && 
+					    world.getBlockId(x+1, j+y+1, z+1) != blockID && 
+					    world.getBlockId(x+1, j+y+1, z-1) != blockID) {
+		                    reachedTop = true;
+				    }
+       			}
+       		}
+        	y++;
+       	}
+        while (y >= 0) {
+            scanLogs(ts.updateCoords(i,j+y,k,6,y--,6));
+        }
+    }
 
-			y++;
-		}
-		while (y >= 0) {
-			scanLogs(world,i,j+y,k,l,checkArray,(byte)6,(byte)y--,(byte)6, stack);
-		}
+    private void scanLogs(TreeScan ts)
+    {
+    	if (ts.y < 0) return;
 
-	}
+        ts.checkArray[ts.x][ts.y][ts.z] = true;
+        int offsetX = 0;int offsetY = 0;int offsetZ = 0;
+        
+        for (offsetX = -2; offsetX <= 2; offsetX++)
+        {
+        	if (ts.x+offsetX >= ts.xLength || ts.x+offsetX < 0) continue;
+
+            for (offsetZ = -2; offsetZ <= 2; offsetZ++)
+            {
+            	if (ts.z+offsetZ >= ts.zLength || ts.z+offsetZ < 0) continue;
+
+				if (ts.checkArray[ts.x+offsetX][ts.y][ts.z+offsetZ]) continue;
+
+				if (!checkOut(ts.world, ts.i+offsetX, ts.j, ts.k+offsetZ, ts.l)) continue;
+
+				scanLogs(ts.updateCoords(ts.i+offsetX, ts.j, ts.k+offsetZ, ts.x+offsetX,ts.y,ts.z+offsetZ));
+            }
+        }
+        
+        damage++;
+        if(ts.stack == null)
+        {
+            ts.world.setBlockToAir(ts.i, ts.j, ts.k);
+            dropBlockAsItem_do(ts.world, ts.i, ts.j, ts.k, new ItemStack(Item.itemsList[TFCItems.Logs.itemID],1,ts.l));
+            return;
+        }
+
+        if(damage+ts.stack.getItemDamage() <= ts.stack.getMaxDamage())
+        {
+            ts.world.setBlock(ts.i, ts.j, ts.k, 0, 0, 0x3);
+            if((isStone && ts.world.rand.nextInt(10) != 0) || !isStone)
+                dropBlockAsItem_do(ts.world, ts.i, ts.j, ts.k, new ItemStack(Item.itemsList[TFCItems.Logs.itemID],1,ts.l));
+        }
+    }
+
 
 	@Override
 	public int idDropped(int i, Random random, int j)
@@ -225,64 +301,28 @@ public class BlockLogNatural extends BlockTerra
 	public void onNeighborBlockChange(World world, int i, int j, int k, int l)
 	{
 		boolean check = false;
-		for(int h = -2; h <= 2; h++)
+		
+		int ijkMetadata = world.getBlockMetadata(i, j, k);
+		
+		for (int h = -2; h <= 2; h++)
 		{
-			for(int g = -2; g <= 2; g++)
+			for (int g = -2; g <= 2; g++)
 			{
-				for(int f = -2; f <= 2; f++)
+				for (int f = -2; f <= 2; f++)
 				{
-					if(world.getBlockId(i+h, j+g, k+f) == blockID && world.getBlockMetadata(i+h, j+g, k+f) == world.getBlockMetadata(i, j, k))
+					if (world.getBlockId(i+h, j+g, k+f) == blockID && world.getBlockMetadata(i+h, j+g, k+f) == ijkMetadata)
 					{
 						check = true;
+						break;
 					}
 				}
 			}
 		}
-		if(!check)
-		{
-			world.setBlock(i, j, k, 0, 0, 0x2);
-			dropBlockAsItem_do(world, i, j, k, new ItemStack(Item.itemsList[TFCItems.Logs.itemID],1,l));
-		}
+		
+		if (check) 
+			return;
+		
+		world.setBlock(i, j, k, 0, 0, 0x2);
+		dropBlockAsItem_do(world, i, j, k, new ItemStack(Item.itemsList[TFCItems.Logs.itemID],1,l));
 	}
-
-	private void scanLogs(World world, int i, int j, int k, int l, boolean[][][] checkArray,byte x, byte y, byte z, ItemStack stack)
-	{
-		if(y >= 0)
-		{
-			checkArray[x][y][z] = true;
-			int offsetX = 0;int offsetY = 0;int offsetZ = 0;
-			
-			for (offsetX = -2; offsetX <= 2; offsetX++)
-			{
-				for (offsetZ = -2; offsetZ <= 2; offsetZ++)
-				{
-					if(x+offsetX < 11 && x+offsetX >= 0 && z+offsetZ < 11 && z+offsetZ >= 0)
-					{
-						if(checkOut(world, i+offsetX, j, k+offsetZ, l) && !checkArray[x+offsetX][y][z+offsetZ])
-						{
-							scanLogs(world,i+offsetX, j, k+offsetZ, l, checkArray,(byte)(x+offsetX),(byte)y,(byte)(z+offsetZ), stack);
-						}
-					}
-				}
-			}
-
-			
-			damage++;
-			if(stack != null)
-			{
-				if(damage+stack.getItemDamage() <= stack.getMaxDamage())
-				{
-					world.setBlock(i, j, k, 0, 0, 0x3);
-					if((isStone && world.rand.nextInt(10) != 0) || !isStone)
-						dropBlockAsItem_do(world, i, j, k, new ItemStack(Item.itemsList[TFCItems.Logs.itemID],1,l));
-				}
-			}
-			else
-			{
-				world.setBlockToAir(i, j, k);
-				dropBlockAsItem_do(world, i, j, k, new ItemStack(Item.itemsList[TFCItems.Logs.itemID],1,l));
-			}
-		}
-	}
-
 }

--- a/TFC_Shared/src/TFC/Blocks/BlockLogNatural.java
+++ b/TFC_Shared/src/TFC/Blocks/BlockLogNatural.java
@@ -29,24 +29,24 @@ public class BlockLogNatural extends BlockTerra
 	}
 	
 	@Override
-    public void updateTick(World world, int i, int j, int k, Random rand)
-    {
+	public void updateTick(World world, int i, int j, int k, Random rand)
+	{
 		if (world.isRemote) return;
 		
 		if (world.isBlockOpaqueCube(i, j-1, k)) return;
 		
 		if (world.getBlockId(i+1, j, k  ) == blockID || 
-		    world.getBlockId(i-1, j, k  ) == blockID || 
-		    world.getBlockId(i  , j, k+1) == blockID || 
-		    world.getBlockId(i  , j, k-1) == blockID || 
-		    world.getBlockId(i+1, j, k+1) == blockID || 
-		    world.getBlockId(i+1, j, k-1) == blockID || 
-		    world.getBlockId(i-1, j, k+1) == blockID || 
-		    world.getBlockId(i-1, j, k-1) == blockID) 
+			world.getBlockId(i-1, j, k  ) == blockID || 
+			world.getBlockId(i  , j, k+1) == blockID || 
+			world.getBlockId(i  , j, k-1) == blockID || 
+			world.getBlockId(i+1, j, k+1) == blockID || 
+			world.getBlockId(i+1, j, k-1) == blockID || 
+			world.getBlockId(i-1, j, k+1) == blockID || 
+			world.getBlockId(i-1, j, k-1) == blockID) 
 			return;
 		
 		world.setBlock(i, j, k, 0);
-    }
+	}
 
 	@SideOnly(Side.CLIENT)
 	@Override
@@ -92,15 +92,15 @@ public class BlockLogNatural extends BlockTerra
 	public static Icon[] rotatedSideIcons = new Icon[Global.WOOD_ALL.length];
 	
 	@Override
-    public void registerIcons(IconRegister registerer)
-    {
+	public void registerIcons(IconRegister registerer)
+	{
 		for (int i = 0; i < Global.WOOD_ALL.length; i++)
 		{
 			sideIcons[i] = registerer.registerIcon(Reference.ModID + ":" + "wood/trees/" + Global.WOOD_ALL[i] + " Log");
 			innerIcons[i] = registerer.registerIcon(Reference.ModID + ":" + "wood/trees/" + Global.WOOD_ALL[i] + " Log Top");
 			rotatedSideIcons[i] = registerer.registerIcon(Reference.ModID + ":" + "wood/trees/" + Global.WOOD_ALL[i] + " Log Side");
 		}
-    }
+	}
 
 	static int damage = 0;
 	boolean isStone = false;
@@ -131,14 +131,14 @@ public class BlockLogNatural extends BlockTerra
 				break;
 			}
 		}
-//		if (!isAxeorSaw) 
-//		{
-//			for(int cnt = 0; cnt < Recipes.Saws.length; cnt++)
-//			{
-//				if(equip.getItem() == Recipes.Saws[cnt])
-//					isAxeorSaw = true;
-//			}
-//		}
+		//if (!isAxeorSaw) 
+		//{
+		//	for(int cnt = 0; cnt < Recipes.Saws.length; cnt++)
+		//	{
+		//		if(equip.getItem() == Recipes.Saws[cnt])
+		//		isAxeorSaw = true;
+		//	}
+		//}
 		if (!isAxeorSaw) {
 			for (int cnt = 0; cnt < Recipes.Hammers.length; cnt++)
 			{
@@ -173,9 +173,9 @@ public class BlockLogNatural extends BlockTerra
 	
 	@Override
 	public boolean canBlockStay(World par1World, int par2, int par3, int par4)
-    {
-        return true;
-    }
+	{
+		return true;
+	}
 
 	@Override
 	public void onBlockDestroyedByExplosion(World world, int i, int j, int k, Explosion ex) 
@@ -183,112 +183,112 @@ public class BlockLogNatural extends BlockTerra
 		ProcessTree(world, i, j, k, world.getBlockMetadata(i, j, k), null);
 	}
 
-    class TreeScan {
-    	public World world;
-        public int i;
-        public int j;
-        public int k;
-        public int l;
-        public boolean checkArray[][][];
-        public int x;
-        public int y;
-        public int z;
-        public ItemStack stack;
-        public int xLength;
-        public int zLength;
-        public TreeScan(World world, int i, int j, int k, int l, boolean[][][] checkArray,int x, int y, int z, ItemStack stack) {
-        	this.world = world;
-            this.i = i;
-            this.j = j;
-            this.k = k;
-            this.l = l;
-            this.checkArray = checkArray;
-            this.x = x;
-            this.y = y;
-            this.z = z;
-            this.stack = stack;
-            this.xLength = checkArray.length;
-            this.zLength = checkArray[0][0].length;
-        }
-        /**
-         * Recursion helper that creates a new instance with updated coordinates
-         * @return Returns a new scanner with the provided coordinates to help recursion
-         */
-        public TreeScan updateCoords(int i, int j, int k, int x, int y, int z) {
-        	return new TreeScan(this.world, i, j, k, this.l, this.checkArray, x, y, z, this.stack);
-        }
-    }
-    
-    private void ProcessTree(World world, int i, int j, int k, int l, ItemStack stack)
-    {
-    	TreeScan ts = new TreeScan(world, i, j, k, l, new boolean[11][50][11], 6, 0, 6, stack);
-        int x = i;
-        int y = 0;
-        int z = k;
+	class TreeScan {
+		public World world;
+		public int i;
+		public int j;
+		public int k;
+		public int l;
+		public boolean checkArray[][][];
+		public int x;
+		public int y;
+		public int z;
+		public ItemStack stack;
+		public int xLength;
+		public int zLength;
+		public TreeScan(World world, int i, int j, int k, int l, boolean[][][] checkArray,int x, int y, int z, ItemStack stack) {
+			this.world = world;
+			this.i = i;
+			this.j = j;
+			this.k = k;
+			this.l = l;
+			this.checkArray = checkArray;
+			this.x = x;
+			this.y = y;
+			this.z = z;
+			this.stack = stack;
+			this.xLength = checkArray.length;
+			this.zLength = checkArray[0][0].length;
+		}
+		/**
+		 * Recursion helper that creates a new instance with updated coordinates
+		 * @return Returns a new scanner with the provided coordinates to help recursion
+		 */
+		public TreeScan updateCoords(int i, int j, int k, int x, int y, int z) {
+			return new TreeScan(this.world, i, j, k, this.l, this.checkArray, x, y, z, this.stack);
+		}
+	}
+	
+	private void ProcessTree(World world, int i, int j, int k, int l, ItemStack stack)
+	{
+		TreeScan ts = new TreeScan(world, i, j, k, l, new boolean[11][50][11], 6, 0, 6, stack);
+		int x = i;
+		int y = 0;
+		int z = k;
 
-        boolean reachedTop = false;
-       	while (!reachedTop) {
-       		if (world.getBlockId(x, j+y+1, z) == 0) {
-       			if (l != 9 && l != 15) {
-                    reachedTop = true;
-       			} else {
+		boolean reachedTop = false;
+		while (!reachedTop) {
+			if (world.getBlockId(x, j+y+1, z) == 0) {
+				if (l != 9 && l != 15) {
+					reachedTop = true;
+				} else {
 					if (world.getBlockId(x+1, j+y+1, z  ) != blockID && 
 						world.getBlockId(x-1, j+y+1, z  ) != blockID && 
-					    world.getBlockId(x  , j+y+1, z+1) != blockID && 
-					    world.getBlockId(x  , j+y+1, z-1) != blockID && 
-					    world.getBlockId(x-1, j+y+1, z-1) != blockID && 
-					    world.getBlockId(x-1, j+y+1, z+1) != blockID && 
-					    world.getBlockId(x+1, j+y+1, z+1) != blockID && 
-					    world.getBlockId(x+1, j+y+1, z-1) != blockID) {
-		                    reachedTop = true;
-				    }
-       			}
-       		}
-        	y++;
-       	}
-        while (y >= 0) {
-            scanLogs(ts.updateCoords(i,j+y,k,6,y--,6));
-        }
-    }
+						world.getBlockId(x  , j+y+1, z+1) != blockID && 
+						world.getBlockId(x  , j+y+1, z-1) != blockID && 
+						world.getBlockId(x-1, j+y+1, z-1) != blockID && 
+						world.getBlockId(x-1, j+y+1, z+1) != blockID && 
+						world.getBlockId(x+1, j+y+1, z+1) != blockID && 
+						world.getBlockId(x+1, j+y+1, z-1) != blockID) {
+							reachedTop = true;
+					}
+				}
+			}
+			y++;
+		}
+		while (y >= 0) {
+			scanLogs(ts.updateCoords(i,j+y,k,6,y--,6));
+		}
+	}
 
-    private void scanLogs(TreeScan ts)
-    {
-    	if (ts.y < 0) return;
+	private void scanLogs(TreeScan ts)
+	{
+		if (ts.y < 0) return;
 
-        ts.checkArray[ts.x][ts.y][ts.z] = true;
-        int offsetX = 0;int offsetY = 0;int offsetZ = 0;
-        
-        for (offsetX = -2; offsetX <= 2; offsetX++)
-        {
-        	if (ts.x+offsetX >= ts.xLength || ts.x+offsetX < 0) continue;
+		ts.checkArray[ts.x][ts.y][ts.z] = true;
+		int offsetX = 0;int offsetY = 0;int offsetZ = 0;
+		
+		for (offsetX = -2; offsetX <= 2; offsetX++)
+		{
+			if (ts.x+offsetX >= ts.xLength || ts.x+offsetX < 0) continue;
 
-            for (offsetZ = -2; offsetZ <= 2; offsetZ++)
-            {
-            	if (ts.z+offsetZ >= ts.zLength || ts.z+offsetZ < 0) continue;
+			for (offsetZ = -2; offsetZ <= 2; offsetZ++)
+			{
+				if (ts.z+offsetZ >= ts.zLength || ts.z+offsetZ < 0) continue;
 
 				if (ts.checkArray[ts.x+offsetX][ts.y][ts.z+offsetZ]) continue;
 
 				if (!checkOut(ts.world, ts.i+offsetX, ts.j, ts.k+offsetZ, ts.l)) continue;
 
 				scanLogs(ts.updateCoords(ts.i+offsetX, ts.j, ts.k+offsetZ, ts.x+offsetX,ts.y,ts.z+offsetZ));
-            }
-        }
-        
-        damage++;
-        if(ts.stack == null)
-        {
-            ts.world.setBlockToAir(ts.i, ts.j, ts.k);
-            dropBlockAsItem_do(ts.world, ts.i, ts.j, ts.k, new ItemStack(Item.itemsList[TFCItems.Logs.itemID],1,ts.l));
-            return;
-        }
+			}
+		}
+		
+		damage++;
+		if(ts.stack == null)
+		{
+			ts.world.setBlockToAir(ts.i, ts.j, ts.k);
+			dropBlockAsItem_do(ts.world, ts.i, ts.j, ts.k, new ItemStack(Item.itemsList[TFCItems.Logs.itemID],1,ts.l));
+			return;
+		}
 
-        if(damage+ts.stack.getItemDamage() <= ts.stack.getMaxDamage())
-        {
-            ts.world.setBlock(ts.i, ts.j, ts.k, 0, 0, 0x3);
-            if((isStone && ts.world.rand.nextInt(10) != 0) || !isStone)
-                dropBlockAsItem_do(ts.world, ts.i, ts.j, ts.k, new ItemStack(Item.itemsList[TFCItems.Logs.itemID],1,ts.l));
-        }
-    }
+		if(damage+ts.stack.getItemDamage() <= ts.stack.getMaxDamage())
+		{
+			ts.world.setBlock(ts.i, ts.j, ts.k, 0, 0, 0x3);
+			if((isStone && ts.world.rand.nextInt(10) != 0) || !isStone)
+				dropBlockAsItem_do(ts.world, ts.i, ts.j, ts.k, new ItemStack(Item.itemsList[TFCItems.Logs.itemID],1,ts.l));
+		}
+	}
 
 
 	@Override


### PR DESCRIPTION
- Reduce stack pressure using a helper class. Now allows handling of trees 7.75 times taller [up to 229 blocks of trunk height if needed]
- Rewrite logic for improved readability
  - Early exit from functions where possible
  - Leave tool identification loops as soon as item is recognized
  - When scanning trees, skip invalid rows or columns instead of checking every invalid block
  - Do inexpensive tests first, and expensive tests later
  - Normalize white space
